### PR TITLE
hotfix/guestCreateShortUrlSuccessPopupNotWorking

### DIFF
--- a/src/store/shortUrl-action.jsx
+++ b/src/store/shortUrl-action.jsx
@@ -102,11 +102,13 @@ export const createShortUrl = (shortUrl) => {
           );
         }
 
-        dispatch(
-          googleAuthActions.updateUserShortUrlPath({
-            short_url_path: res?.data?.short_url_path,
-          })
-        );
+        if(res?.data?.short_url_path){ // update the shortUrlPath, only if its a login user
+          dispatch(
+            googleAuthActions.updateUserShortUrlPath({
+              short_url_path: res?.data?.short_url_path,
+            })
+          );
+        }
 
         return dispatch(
             shortUrlActions.updateShortUrl({


### PR DESCRIPTION
fix issue where the guest create shorturl success popup not working in frontend. Making guest user unable to get the actual shorturl generated by system